### PR TITLE
feat: branch.autocheck - автопометка веток по regex-правилам

### DIFF
--- a/.commitlint.yml
+++ b/.commitlint.yml
@@ -1,0 +1,44 @@
+# Локальный конфиг для Go commitlint (commitlint-go)
+# Используется .githooks/commit-msg через --config .commitlint.yml
+# GitHub Actions использует commitlint.config.mjs (Node.js версия)
+
+min-version: v0.11.0
+formatter: default
+rules:
+    - header-min-length
+    - header-max-length
+    - footer-max-line-length
+    - body-max-line-length
+    - type-enum
+severity:
+    default: error
+    rules: {}
+settings:
+    header-min-length:
+        argument: 10
+        flags: {}
+    header-max-length:
+        argument: 100
+        flags: {}
+    footer-max-line-length:
+        argument: 100
+        flags: {}
+    body-max-line-length:
+        argument: 0
+        flags: {}
+    type-enum:
+        argument:
+            - feat
+            - fix
+            - docs
+            - style
+            - refactor
+            - perf
+            - test
+            - build
+            - ci
+            - chore
+            - revert
+        flags: {}
+disable-default-ignores: false
+ignores: []

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -4,13 +4,13 @@
 # Использует конфиг: .commitlint.yml (YAML)
 # GitHub Actions использует: commitlint.config.mjs (Node.js версия)
 
-if command -v commitlint >/dev/null 2>&1; then
-	commitlint lint --config .commitlint.yml --message "$1"
+if [ -x "$(go env GOPATH)/bin/commitlint" ]; then
+	"$(go env GOPATH)/bin/commitlint" lint --config .commitlint.yml --message "$1"
 	exit $?
 fi
 
-if [ -x "$(go env GOPATH)/bin/commitlint" ]; then
-	"$(go env GOPATH)/bin/commitlint" lint --config .commitlint.yml --message "$1"
+if command -v commitlint >/dev/null 2>&1; then
+	commitlint lint --config .commitlint.yml --message "$1"
 	exit $?
 fi
 

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,13 +1,16 @@
 #!/bin/sh
 
-# Проверяем формат сообщения коммита через установленный бинарь commitlint
+# Локальный hook для commitlint (Go версия)
+# Использует конфиг: .commitlint.yml (YAML)
+# GitHub Actions использует: commitlint.config.mjs (Node.js версия)
+
 if command -v commitlint >/dev/null 2>&1; then
-	commitlint lint --message "$1"
+	commitlint lint --config .commitlint.yml --message "$1"
 	exit $?
 fi
 
 if [ -x "$(go env GOPATH)/bin/commitlint" ]; then
-	"$(go env GOPATH)/bin/commitlint" lint --message "$1"
+	"$(go env GOPATH)/bin/commitlint" lint --config .commitlint.yml --message "$1"
 	exit $?
 fi
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -5,11 +5,35 @@ export default {
     (message) => message.includes('CodeRabbit'),
   ],
   rules: {
+    // Минимальная длина заголовка коммита: 10 символов
+    // Синхронизировано с .commitlint.yml (Go commitlint)
+    'header-min-length': [2, 'always', 10],
+
     // Максимальная длина заголовка коммита: 100 символов
     // Синхронизировано с .commitlint.yml (Go commitlint)
     'header-max-length': [2, 'always', 100],
 
+    // Максимальная длина строки в footer: 100 символов
+    // Синхронизировано с .commitlint.yml (Go commitlint)
+    'footer-max-line-length': [2, 'always', 100],
+
     // Отключаем ограничение длины body (боты и URL часто превышают 100)
     'body-max-line-length': [0],
+
+    // Разрешённые типы коммитов
+    // Синхронизировано с .commitlint.yml (Go commitlint)
+    'type-enum': [2, 'always', [
+      'feat',
+      'fix',
+      'docs',
+      'style',
+      'refactor',
+      'perf',
+      'test',
+      'build',
+      'ci',
+      'chore',
+      'revert',
+    ]],
   }
 };

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -5,7 +5,11 @@ export default {
     (message) => message.includes('CodeRabbit'),
   ],
   rules: {
-    // Disable max line length for the commit body because bots and URLs often exceed 100 chars
+    // Максимальная длина заголовка коммита: 100 символов
+    // Синхронизировано с .commitlint.yml (Go commitlint)
+    'header-max-length': [2, 'always', 100],
+
+    // Отключаем ограничение длины body (боты и URL часто превышают 100)
     'body-max-line-length': [0],
   }
 };

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,6 +11,9 @@ repos:
     branch:
       keep:
         - '^main$'
+      autocheck:
+        - '^feature/.*$'
+        - '^bugfix/.*$'
 
   - name: 'MariaDB Connector/C'
     url: git@github.com:mariadb-corporation/mariadb-connector-c.git

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	jiraByGroup map[string]JiraConfig
 }
 
+// BrowserConfig содержит настройки подключения к браузеру (например, через CDP).
 type BrowserConfig struct {
 	CDPURL string `yaml:"cdp_url" mapstructure:"cdp_url"`
 }
@@ -63,11 +64,13 @@ type JiraConfig struct {
 	Token      string    `yaml:"token" mapstructure:"token"`
 }
 
+// JiraLogin хранит учетные данные для базовой аутентификации в Jira.
 type JiraLogin struct {
 	Username string `yaml:"username" mapstructure:"username"`
 	Password string `yaml:"password" mapstructure:"password"`
 }
 
+// JiraMatch содержит результат успешного сопоставления ветки с тикетом в Jira.
 type JiraMatch struct {
 	Key       string
 	Group     string
@@ -85,6 +88,7 @@ const (
 	JiraMatchReasonFallbackFullMatch JiraMatchReason = "fallback_full_match"
 )
 
+// JiraMatchDiagnostics описывает детали процесса сопоставления для отладки.
 type JiraMatchDiagnostics struct {
 	Reason  JiraMatchReason
 	Pattern string
@@ -92,6 +96,7 @@ type JiraMatchDiagnostics struct {
 	Key     string
 }
 
+// compiledPattern хранит скомпилированное регулярное выражение и его исходную строку.
 type compiledPattern struct {
 	raw string
 	re  *regexp.Regexp
@@ -213,6 +218,7 @@ type repoIdentityRef struct {
 	name  string
 }
 
+// validateRepoIdentityConflicts проверяет список репозиториев на наличие дубликатов имен или путей.
 func validateRepoIdentityConflicts(repos []RepoConfig) error {
 	nameOwners := make(map[string]repoIdentityRef, len(repos))
 	workdirOwners := make(map[string]repoIdentityRef, len(repos))
@@ -248,6 +254,7 @@ func validateRepoIdentityConflicts(repos []RepoConfig) error {
 	return fmt.Errorf("ошибка конфигурации: обнаружены конфликтующие репозитории. Приложение остановлено до исправления config.yaml:\n%s", strings.Join(conflicts, "\n"))
 }
 
+// repoWorkdirKey генерирует уникальный ключ для рабочего каталога репозитория.
 func repoWorkdirKey(repo RepoConfig) string {
 	if repo.Path != "" {
 		return "path:" + repo.Path
@@ -256,6 +263,7 @@ func repoWorkdirKey(repo RepoConfig) string {
 	return "managed:" + managedRepoDirKey(repo.Name, repo.URL)
 }
 
+// managedRepoDirKey возвращает путь к каталогу для автоматически управляемого репозитория.
 func managedRepoDirKey(repoName, repoURL string) string {
 	return workdir.ManagedRepoDirKey(repoName, repoURL)
 }
@@ -274,6 +282,7 @@ func (r RepoConfig) SourceType() string {
 	return "url"
 }
 
+// compilePatterns компилирует список строк в регулярные выражения.
 func compilePatterns(patterns []string) ([]*compiledPattern, error) {
 	result := make([]*compiledPattern, 0, len(patterns))
 	for _, pattern := range patterns {
@@ -288,6 +297,7 @@ func compilePatterns(patterns []string) ([]*compiledPattern, error) {
 
 var scpLikeGitURLRE = regexp.MustCompile(`^[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:[A-Za-z0-9._~/-]+(?:\.git)?$`)
 
+// validateRepoURL проверяет корректность Git URL (HTTP/SSH/SCP).
 func validateRepoURL(raw string) error {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -319,6 +329,7 @@ func validateRepoURL(raw string) error {
 	return nil
 }
 
+// validateBrowserCDPURL проверяет валидность URL для CDP подключения.
 func validateBrowserCDPURL(raw string) error {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -343,6 +354,7 @@ func validateBrowserCDPURL(raw string) error {
 	return nil
 }
 
+// validateJiraURL проверяет корректность базового URL Jira (только HTTPS).
 func validateJiraURL(raw string) error {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -511,10 +523,12 @@ func (r RepoConfig) ExtractJiraMatchDetailed(branch string) (JiraMatch, bool, Ji
 	return JiraMatch{}, false, JiraMatchDiagnostics{Reason: JiraMatchReasonNoRegexMatch}
 }
 
+// normalizeJiraBaseURL очищает и нормализует базовый URL Jira.
 func normalizeJiraBaseURL(raw string) string {
 	return strings.TrimRight(strings.TrimSpace(raw), "/")
 }
 
+// jiraTicketURL формирует полную ссылку на задачу в Jira.
 func jiraTicketURL(baseURL, ticket string) string {
 	baseURL = normalizeJiraBaseURL(baseURL)
 	ticket = strings.TrimSpace(ticket)
@@ -591,6 +605,7 @@ func ScanDirectory(ctx context.Context, dir string) (*Config, error) {
 	return &Config{Repos: repos}, nil
 }
 
+// readOriginURL пытается получить URL удаленного репозитория 'origin' для заданной директории.
 func readOriginURL(ctx context.Context, repoDir string) (string, bool) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,8 +37,9 @@ type RepoConfig struct {
 	Path   string `yaml:"path" mapstructure:"path"`
 	Branch Branch `yaml:"branch" mapstructure:"branch"`
 
-	keep []*compiledPattern
-	jira []*compiledPattern
+	keep      []*compiledPattern
+	jira      []*compiledPattern
+	autocheck []*compiledPattern
 
 	jiraGroups map[string]JiraConfig
 }
@@ -48,6 +49,7 @@ type Branch struct {
 	Autoswitch string   `yaml:"autoswitch,omitempty" mapstructure:"autoswitch"`
 	Keep       []string `yaml:"keep" mapstructure:"keep"`
 	Jira       []string `yaml:"jira" mapstructure:"jira"`
+	Autocheck  []string `yaml:"autocheck" mapstructure:"autocheck"`
 }
 
 // JiraConfig парсит верхнеуровневый раздел jira интеграций.
@@ -189,6 +191,11 @@ func LoadFromViper(v *viper.Viper) (*Config, error) {
 		repo.jira, err = compilePatterns(repo.Branch.Jira)
 		if err != nil {
 			return nil, fmt.Errorf("repo[%s]: branch.jira: %w", repo.Name, err)
+		}
+
+		repo.autocheck, err = compilePatterns(repo.Branch.Autocheck)
+		if err != nil {
+			return nil, fmt.Errorf("repo[%s]: branch.autocheck: %w", repo.Name, err)
 		}
 
 		repo.jiraGroups = cfg.jiraByGroup
@@ -400,6 +407,17 @@ func (r RepoConfig) ProtectedReason(branch string) (string, bool) {
 	}
 
 	return "", false
+}
+
+// MatchesAutocheck проверяет, совпадает ли имя ветки с любым из branch.autocheck правил.
+// Возвращает false при пустом autocheck (no-op).
+func (r RepoConfig) MatchesAutocheck(branch string) bool {
+	for _, p := range r.autocheck {
+		if p.re.MatchString(branch) {
+			return true
+		}
+	}
+	return false
 }
 
 // ExtractJiraKey пытается извлечь Jira key из ветки по repo.jira regex.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -615,3 +615,109 @@ func runCommand(t *testing.T, workdir string, name string, args ...string) {
 		t.Fatalf("command failed: %s %v\n%s\n%v", name, args, string(out), err)
 	}
 }
+
+func TestLoadParsesBranchAutocheck(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	raw := "repos:\n" +
+		"  - name: test\n" +
+		"    url: https://gitlab.com/anHome/git-branch-cleaner-test.git\n" +
+		"    branch:\n" +
+		"      keep: ['^(main|master)$']\n" +
+		"      autocheck: ['^feature/.*$', '^bugfix/.*$']\n"
+	if err := os.WriteFile(configPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	repo := cfg.Repos[0]
+	if len(repo.Branch.Autocheck) != 2 {
+		t.Fatalf("expected 2 autocheck patterns, got %d", len(repo.Branch.Autocheck))
+	}
+	if !repo.MatchesAutocheck("feature/login") {
+		t.Fatal("feature/login must match autocheck")
+	}
+	if !repo.MatchesAutocheck("bugfix/crash") {
+		t.Fatal("bugfix/crash must match autocheck")
+	}
+	if repo.MatchesAutocheck("main") {
+		t.Fatal("main must not match autocheck")
+	}
+	if repo.MatchesAutocheck("hotfix/urgent") {
+		t.Fatal("hotfix/urgent must not match autocheck")
+	}
+}
+
+func TestAutocheckIsNoOpWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	repo := RepoConfig{}
+	repo.autocheck = nil
+
+	if repo.MatchesAutocheck("anything") {
+		t.Fatal("empty autocheck must not match any branch")
+	}
+}
+
+func TestLoadFailsOnInvalidAutocheckRegex(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	raw := "repos:\n" +
+		"  - name: test\n" +
+		"    url: https://gitlab.com/anHome/git-branch-cleaner-test.git\n" +
+		"    branch:\n" +
+		"      autocheck: ['[invalid']\n"
+	if err := os.WriteFile(configPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(configPath)
+	if err == nil {
+		t.Fatal("expected regex validation error for branch.autocheck")
+	}
+	if !strings.Contains(err.Error(), "branch.autocheck") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAutocheckDoesNotMatchProtectedBranches(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	raw := "repos:\n" +
+		"  - name: test\n" +
+		"    url: https://gitlab.com/anHome/git-branch-cleaner-test.git\n" +
+		"    branch:\n" +
+		"      keep: ['^release/.*$']\n" +
+		"      autocheck: ['^release/.*$', '^feature/.*$']\n"
+	if err := os.WriteFile(configPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	repo := cfg.Repos[0]
+	// autocheck regex совпадает, но ветка защищена через keep
+	if !repo.IsProtected("release/1.0") {
+		t.Fatal("release/1.0 must be protected")
+	}
+	// MatchesAutocheck проверяет только regex, не защиту
+	if !repo.MatchesAutocheck("release/1.0") {
+		t.Fatal("release/1.0 must match autocheck regex")
+	}
+	if !repo.MatchesAutocheck("feature/task") {
+		t.Fatal("feature/task must match autocheck regex")
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -58,6 +58,7 @@ type BranchInfo struct {
 	MergeStatus   MergeStatus
 	Protected     bool
 	Reason        string
+	Autocheck     bool
 }
 
 type JiraStatusState string

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -438,6 +438,16 @@ func (m *Model) invertVisibleBranchSelection(repoName string) int {
 	return toggled
 }
 
+func (m *Model) applyAutocheckSelection(repoName string, branches []model.BranchInfo) {
+	selected := m.ensureRepoSelection(repoName)
+	for _, branch := range branches {
+		if branch.Autocheck && !branch.Protected {
+			key := m.branchSelectionKey(branch)
+			selected[key] = true
+		}
+	}
+}
+
 func onOff(v bool) string {
 	if v {
 		return "вкл"

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agelxnash/go-repo-orchestrator/internal/model"
 )
 
+// ensureRepoSelection гарантирует наличие карты выбранных веток для указанного репозитория.
 func (m *Model) ensureRepoSelection(repoName string) map[string]bool {
 	if _, ok := m.selected[repoName]; !ok {
 		m.selected[repoName] = make(map[string]bool)
@@ -18,6 +19,7 @@ func (m *Model) ensureRepoSelection(repoName string) map[string]bool {
 	return m.selected[repoName]
 }
 
+// ensureRepoState инициализирует состояние (курсор, смещение, выбор) для указанного репозитория, если оно отсутствует.
 func (m *Model) ensureRepoState(repoName string) {
 	_ = m.ensureRepoSelection(repoName)
 	if _, ok := m.branchCursor[repoName]; !ok {
@@ -28,6 +30,7 @@ func (m *Model) ensureRepoState(repoName string) {
 	}
 }
 
+// isSelected проверяет, выбрана ли указанная ветка в данном репозитории.
 func (m Model) isSelected(repoName, key string) bool {
 	repoSelected, ok := m.selected[repoName]
 	if !ok {
@@ -37,6 +40,7 @@ func (m Model) isSelected(repoName, key string) bool {
 	return repoSelected[key]
 }
 
+// selectedBranches возвращает список всех веток репозитория, выбранных пользователем (исключая защищенные).
 func (m Model) selectedBranches(repoName string) []model.BranchInfo {
 	repoSelected, ok := m.selected[repoName]
 	if !ok {
@@ -61,6 +65,7 @@ func (m Model) selectedBranches(repoName string) []model.BranchInfo {
 	return result
 }
 
+// visibleBranches возвращает список веток активного репозитория, отфильтрованных по области видимости (Local/Remote/All) и поисковому запросу.
 func (m Model) visibleBranches() []model.BranchInfo {
 	query := ""
 	if m.searchMode || m.searchInput.Value() != "" {
@@ -98,6 +103,7 @@ func (m Model) visibleBranches() []model.BranchInfo {
 	return visible
 }
 
+// visibleRepoIndices возвращает индексы репозиториев из конфигурации, подходящих под текущий поисковый фильтр.
 func (m Model) visibleRepoIndices() []int {
 	query := ""
 	if m.searchMode || m.searchInput.Value() != "" {
@@ -130,6 +136,7 @@ func (m Model) visibleRepoIndices() []int {
 	return indices
 }
 
+// currentCursor возвращает позицию курсора в списке веток для указанного репозитория.
 func (m Model) currentCursor(repoName string) int {
 	cursor, ok := m.branchCursor[repoName]
 	if !ok {
@@ -138,6 +145,7 @@ func (m Model) currentCursor(repoName string) int {
 	return cursor
 }
 
+// clampBranchCursor удерживает курсор веток в пределах допустимых границ для указанного репозитория.
 func (m *Model) clampBranchCursor(repoName string) {
 	branches := m.visibleBranches()
 	if len(branches) == 0 {
@@ -156,6 +164,7 @@ func (m *Model) clampBranchCursor(repoName string) {
 	m.branchCursor[repoName] = cur
 }
 
+// ensureRepoCursorVisible корректирует смещение вьюпорта репозиториев, чтобы выбранный репозиторий всегда был виден.
 func (m *Model) ensureRepoCursorVisible() {
 	indices := m.visibleRepoIndices()
 	if len(indices) == 0 {
@@ -182,6 +191,7 @@ func (m Model) repoVisiblePosition(indices []int) int {
 	return -1
 }
 
+// ensureBranchCursorVisible корректирует смещение вьюпорта веток, чтобы выбранная ветка всегда была видна.
 func (m *Model) ensureBranchCursorVisible(repoName string) {
 	if repoName == "" {
 		return
@@ -277,6 +287,7 @@ func adjustedViewportOffset(offset, cursor, total, rows int) int {
 	return offset
 }
 
+// currentBranch возвращает информацию о ветке под курсором в активном репозитории.
 func (m Model) currentBranch() *model.BranchInfo {
 	branches := m.visibleBranches()
 	if len(branches) == 0 {
@@ -290,6 +301,7 @@ func (m Model) currentBranch() *model.BranchInfo {
 	return &branch
 }
 
+// selectedRepoName возвращает имя репозитория под курсором в панели репозиториев.
 func (m Model) selectedRepoName() string {
 	if len(m.cfg.Repos) == 0 || m.repoIdx < 0 || m.repoIdx >= len(m.cfg.Repos) {
 		return ""
@@ -382,6 +394,7 @@ func (m Model) repoStatusCode(status string) string {
 	}
 }
 
+// branchSelectionKey возвращает уникальный строковый ключ для идентификации ветки в карте выбранных элементов.
 func (m Model) branchSelectionKey(branch model.BranchInfo) string {
 	if strings.TrimSpace(branch.Key) != "" {
 		return branch.Key
@@ -395,6 +408,7 @@ func (m Model) branchSelectionKey(branch model.BranchInfo) string {
 	return branch.Name
 }
 
+// branchDisplayName возвращает форматированное имя ветки для отображения в интерфейсе (с учетом удаленных репозиториев).
 func (m Model) branchDisplayName(branch model.BranchInfo) string {
 	if branch.IsRemote() && branch.RemoteName != "" {
 		return branch.RemoteName + "/" + branch.Name
@@ -405,6 +419,7 @@ func (m Model) branchDisplayName(branch model.BranchInfo) string {
 	return branch.Name
 }
 
+// branchListName возвращает имя ветки для вывода в списке, добавляя маркеры защиты (*).
 func (m Model) branchListName(branch model.BranchInfo) string {
 	name := m.branchDisplayName(branch)
 	if branch.Protected {
@@ -424,6 +439,7 @@ func (m Model) isBranchSelectable(branch model.BranchInfo) bool {
 	return !branch.Protected
 }
 
+// invertVisibleBranchSelection инвертирует выбор для всех видимых (отфильтрованных) веток, которые не являются защищенными.
 func (m *Model) invertVisibleBranchSelection(repoName string) int {
 	selected := m.ensureRepoSelection(repoName)
 	toggled := 0
@@ -438,12 +454,20 @@ func (m *Model) invertVisibleBranchSelection(repoName string) int {
 	return toggled
 }
 
+// applyAutocheckSelection помечает ветки для автоматического выбора на основе правил из конфигурации.
+// Данная функция вызывается при загрузке списка веток репозитория.
+// Она уважает ручной выбор пользователя: если ветка уже присутствует в списке выбранных (или явно снятых),
+// значение не перезаписывается.
 func (m *Model) applyAutocheckSelection(repoName string, branches []model.BranchInfo) {
 	selected := m.ensureRepoSelection(repoName)
 	for _, branch := range branches {
 		if branch.Autocheck && !branch.Protected {
 			key := m.branchSelectionKey(branch)
-			selected[key] = true
+			// Применяем автоматический выбор только если для этой ветки еще нет сохраненного состояния
+			// (пользователь еще не нажимал пробел для этой ветки в текущей сессии).
+			if _, exists := selected[key]; !exists {
+				selected[key] = true
+			}
 		}
 	}
 }
@@ -569,6 +593,7 @@ func truncate(s string, limit int) string {
 	return string(runes[:limit-1]) + "…"
 }
 
+// fitCell усекает строку до заданной ширины и дополняет пробелами для выравнивания в ячейке.
 func fitCell(s string, width int) string {
 	if width <= 0 {
 		return ""

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -284,6 +284,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.repoData[msg.repoName] = msg.rb
+		m.applyAutocheckSelection(msg.repoName, msg.rb.Branches)
 		syncWarning := strings.TrimSpace(msg.rb.SyncWarning)
 		if syncWarning != "" {
 			if friendly := userFacingError(errors.New(syncWarning)); friendly != nil {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1338,6 +1338,7 @@ func TestRemoteScopeViewportStaysVisibleAfterScrollDownAndUp(t *testing.T) {
 			current := caseModel.currentBranch()
 			if current == nil {
 				t.Fatalf("%s: expected current branch while scrolling", name)
+				return // unreachable, satisfies staticcheck SA5011
 			}
 			panel := caseModel.viewBranchesPanel(120, branchesHeight)
 			display := caseModel.branchDisplayName(*current)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2105,3 +2105,39 @@ func TestAutocheckSelectionIsIdempotent(t *testing.T) {
 		t.Fatal("expected feature/task to remain selected")
 	}
 }
+
+func TestManualOverridePersistsAfterRefresh(t *testing.T) {
+	m := NewModel(&config.Config{
+		Repos: []config.RepoConfig{{Name: "repo-a", Path: "/tmp/repo-a"}},
+	}, nil, false)
+
+	branches := []model.BranchInfo{
+		{Name: "feature/task", Key: "refs/heads/feature/task", Scope: model.BranchScopeLocal, Autocheck: true},
+	}
+
+	// 1. Initial autocheck
+	m.applyAutocheckSelection("repo-a", branches)
+	if !m.selected["repo-a"]["refs/heads/feature/task"] {
+		t.Fatal("expected initial auto-selection")
+	}
+
+	// 2. Manual unselect via Update
+	m.focus = focusBranches
+	m.activeRepo = model.RepoBranches{RepoName: "repo-a", Branches: branches}
+	m.repoStats["repo-a"] = model.RepoStat{Loaded: true}
+	m.branchCursor["repo-a"] = 0
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = updated.(Model)
+
+	if m.selected["repo-a"]["refs/heads/feature/task"] {
+		t.Fatal("expected manual unselect to work")
+	}
+
+	// 3. Refresh (re-apply autocheck) - should NOT re-select
+	m.applyAutocheckSelection("repo-a", branches)
+
+	if m.selected["repo-a"]["refs/heads/feature/task"] {
+		t.Fatal("expected manual unselect to persist after re-applying autocheck")
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1984,3 +1984,123 @@ func TestF6HintVisibleInTopMenuAndHotkeyBar(t *testing.T) {
 		t.Fatalf("expected F6 in branches hotkey bar, got %q", bar)
 	}
 }
+
+func TestApplyAutocheckSelectionMarksEligibleBranches(t *testing.T) {
+	m := NewModel(&config.Config{
+		Repos: []config.RepoConfig{{Name: "repo-a", Path: "/tmp/repo-a"}},
+	}, nil, false)
+
+	branches := []model.BranchInfo{
+		{Name: "feature/task", Key: "refs/heads/feature/task", Scope: model.BranchScopeLocal, Autocheck: true},
+		{Name: "bugfix/fix", Key: "refs/heads/bugfix/fix", Scope: model.BranchScopeLocal, Autocheck: true},
+		{Name: "hotfix/urgent", Key: "refs/heads/hotfix/urgent", Scope: model.BranchScopeLocal, Autocheck: false},
+		{Name: "release/1.0", Key: "refs/heads/release/1.0", Scope: model.BranchScopeLocal, Autocheck: true, Protected: true},
+	}
+
+	m.applyAutocheckSelection("repo-a", branches)
+
+	selected := m.selected["repo-a"]
+	if !selected["refs/heads/feature/task"] {
+		t.Fatal("expected feature/task to be auto-selected")
+	}
+	if !selected["refs/heads/bugfix/fix"] {
+		t.Fatal("expected bugfix/fix to be auto-selected")
+	}
+	if selected["refs/heads/hotfix/urgent"] {
+		t.Fatal("expected hotfix/urgent to NOT be auto-selected (Autocheck=false)")
+	}
+	if selected["refs/heads/release/1.0"] {
+		t.Fatal("expected release/1.0 to NOT be auto-selected (Protected=true)")
+	}
+}
+
+func TestManualOverrideCanUnselectAutocheckBranch(t *testing.T) {
+	m := NewModel(&config.Config{
+		Repos: []config.RepoConfig{{Name: "repo-a", Path: "/tmp/repo-a"}},
+	}, nil, false)
+
+	branches := []model.BranchInfo{
+		{Name: "feature/task", Key: "refs/heads/feature/task", Scope: model.BranchScopeLocal, Autocheck: true},
+	}
+
+	// Simulate autocheck selection
+	m.applyAutocheckSelection("repo-a", branches)
+
+	// Verify initial state
+	if !m.selected["repo-a"]["refs/heads/feature/task"] {
+		t.Fatal("expected feature/task to be auto-selected initially")
+	}
+
+	// Simulate manual override: user presses Space on the auto-selected branch
+	m.focus = focusBranches
+	m.branchScope = branchScopeLocal
+	m.activeRepo = model.RepoBranches{
+		RepoName: "repo-a",
+		Branches: branches,
+	}
+	m.repoStats["repo-a"] = model.RepoStat{Loaded: true}
+	m.branchCursor["repo-a"] = 0
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next := updated.(Model)
+
+	// Manual toggle should unselect the auto-selected branch
+	if next.selected["repo-a"]["refs/heads/feature/task"] {
+		t.Fatal("expected manual Space to unselect auto-selected branch")
+	}
+}
+
+func TestManualOverrideCanSelectNonAutocheckBranch(t *testing.T) {
+	m := NewModel(&config.Config{
+		Repos: []config.RepoConfig{{Name: "repo-a", Path: "/tmp/repo-a"}},
+	}, nil, false)
+
+	branches := []model.BranchInfo{
+		{Name: "feature/task", Key: "refs/heads/feature/task", Scope: model.BranchScopeLocal, Autocheck: true},
+		{Name: "hotfix/urgent", Key: "refs/heads/hotfix/urgent", Scope: model.BranchScopeLocal, Autocheck: false},
+	}
+
+	m.applyAutocheckSelection("repo-a", branches)
+
+	// hotfix/urgent should NOT be auto-selected
+	if m.selected["repo-a"]["refs/heads/hotfix/urgent"] {
+		t.Fatal("expected hotfix/urgent to NOT be auto-selected")
+	}
+
+	// Navigate to hotfix/urgent and select manually
+	m.focus = focusBranches
+	m.branchScope = branchScopeLocal
+	m.activeRepo = model.RepoBranches{
+		RepoName: "repo-a",
+		Branches: branches,
+	}
+	m.repoStats["repo-a"] = model.RepoStat{Loaded: true}
+	m.branchCursor["repo-a"] = 1
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next := updated.(Model)
+
+	if !next.selected["repo-a"]["refs/heads/hotfix/urgent"] {
+		t.Fatal("expected manual Space to select non-autocheck branch")
+	}
+}
+
+func TestAutocheckSelectionIsIdempotent(t *testing.T) {
+	m := NewModel(&config.Config{
+		Repos: []config.RepoConfig{{Name: "repo-a", Path: "/tmp/repo-a"}},
+	}, nil, false)
+
+	branches := []model.BranchInfo{
+		{Name: "feature/task", Key: "refs/heads/feature/task", Scope: model.BranchScopeLocal, Autocheck: true},
+	}
+
+	m.applyAutocheckSelection("repo-a", branches)
+	m.applyAutocheckSelection("repo-a", branches)
+
+	if len(m.selected["repo-a"]) != 1 {
+		t.Fatalf("expected exactly 1 selected branch after double apply, got %d", len(m.selected["repo-a"]))
+	}
+	if !m.selected["repo-a"]["refs/heads/feature/task"] {
+		t.Fatal("expected feature/task to remain selected")
+	}
+}

--- a/internal/usecase/branch_cleaner.go
+++ b/internal/usecase/branch_cleaner.go
@@ -162,6 +162,7 @@ func (c *Cleaner) LoadRepoBranches(ctx context.Context, repo config.RepoConfig) 
 		branch.BaseBranch = baseBranch
 		branch.Protected = !allowed
 		branch.Reason = reason
+		branch.Autocheck = !branch.Protected && branch.Name != currentBranch && repo.MatchesAutocheck(branch.Name)
 		filtered = append(filtered, branch)
 	}
 

--- a/internal/usecase/branch_cleaner_sync_test.go
+++ b/internal/usecase/branch_cleaner_sync_test.go
@@ -1042,3 +1042,211 @@ func TestLoadRepoBranchesProtectsAndSkipsRemoteDefaultBranch(t *testing.T) {
 		t.Fatalf("unexpected generate script error: %v", err)
 	}
 }
+
+func TestLoadRepoBranchesSetsAutocheckForMatchingBranches(t *testing.T) {
+	t.Parallel()
+
+	git := &fakeGitClient{
+		resolveRepoPathFn: func(_ context.Context, repoName, repoURL, localPath string) (string, error) {
+			return "/tmp/demo", nil
+		},
+		listBranchesFn: func(_ context.Context, repoPath string) ([]model.BranchInfo, error) {
+			return []model.BranchInfo{
+				{Name: "feature/task-1", QualifiedName: "feature/task-1", Scope: model.BranchScopeLocal},
+				{Name: "bugfix/fix-2", QualifiedName: "bugfix/fix-2", Scope: model.BranchScopeLocal},
+				{Name: "hotfix/urgent", QualifiedName: "hotfix/urgent", Scope: model.BranchScopeLocal},
+			}, nil
+		},
+		currentBranchFn: func(_ context.Context, repoPath string) (string, error) {
+			return "main", nil
+		},
+		detectDefaultBranchFn: func(_ context.Context, repoPath, currentBranch string) (string, error) {
+			return "main", nil
+		},
+	}
+
+	v := viper.New()
+	v.Set("repos", []map[string]any{{
+		"name": "demo",
+		"path": "/tmp/demo",
+		"branch": map[string]any{
+			"autocheck": []string{"^feature/.*$", "^bugfix/.*$"},
+		},
+	}})
+
+	cfg, err := config.LoadFromViper(v)
+	if err != nil {
+		t.Fatalf("load config from viper: %v", err)
+	}
+
+	cleaner := NewCleaner(git)
+	rb, err := cleaner.LoadRepoBranches(context.Background(), cfg.Repos[0])
+	if err != nil {
+		t.Fatalf("load repo branches: %v", err)
+	}
+
+	byName := make(map[string]model.BranchInfo, len(rb.Branches))
+	for _, b := range rb.Branches {
+		byName[b.Name] = b
+	}
+
+	if !byName["feature/task-1"].Autocheck {
+		t.Fatal("feature/task-1 must be autocheck-selected")
+	}
+	if !byName["bugfix/fix-2"].Autocheck {
+		t.Fatal("bugfix/fix-2 must be autocheck-selected")
+	}
+	if byName["hotfix/urgent"].Autocheck {
+		t.Fatal("hotfix/urgent must not be autocheck-selected (no regex match)")
+	}
+}
+
+func TestLoadRepoBranchesAutocheckSkipsProtectedBranches(t *testing.T) {
+	t.Parallel()
+
+	git := &fakeGitClient{
+		resolveRepoPathFn: func(_ context.Context, repoName, repoURL, localPath string) (string, error) {
+			return "/tmp/demo", nil
+		},
+		listBranchesFn: func(_ context.Context, repoPath string) ([]model.BranchInfo, error) {
+			return []model.BranchInfo{
+				{Name: "feature/task", QualifiedName: "feature/task", Scope: model.BranchScopeLocal},
+				{Name: "release/1.0", QualifiedName: "release/1.0", Scope: model.BranchScopeLocal},
+			}, nil
+		},
+		currentBranchFn: func(_ context.Context, repoPath string) (string, error) {
+			return "main", nil
+		},
+		detectDefaultBranchFn: func(_ context.Context, repoPath, currentBranch string) (string, error) {
+			return "main", nil
+		},
+	}
+
+	v := viper.New()
+	v.Set("repos", []map[string]any{{
+		"name": "demo",
+		"path": "/tmp/demo",
+		"branch": map[string]any{
+			"keep":      []string{"^release/.*$"},
+			"autocheck": []string{"^feature/.*$", "^release/.*$"},
+		},
+	}})
+
+	cfg, err := config.LoadFromViper(v)
+	if err != nil {
+		t.Fatalf("load config from viper: %v", err)
+	}
+
+	cleaner := NewCleaner(git)
+	rb, err := cleaner.LoadRepoBranches(context.Background(), cfg.Repos[0])
+	if err != nil {
+		t.Fatalf("load repo branches: %v", err)
+	}
+
+	byName := make(map[string]model.BranchInfo, len(rb.Branches))
+	for _, b := range rb.Branches {
+		byName[b.Name] = b
+	}
+
+	// feature/task: matches autocheck, not protected -> autocheck=true
+	if !byName["feature/task"].Autocheck {
+		t.Fatal("feature/task must be autocheck-selected")
+	}
+	// release/1.0: matches autocheck regex BUT protected by keep -> autocheck=false
+	if byName["release/1.0"].Autocheck {
+		t.Fatal("release/1.0 must not be autocheck-selected (protected by keep)")
+	}
+	if !byName["release/1.0"].Protected {
+		t.Fatal("release/1.0 must be protected")
+	}
+}
+
+func TestLoadRepoBranchesAutocheckSkipsCurrentBranch(t *testing.T) {
+	t.Parallel()
+
+	git := &fakeGitClient{
+		resolveRepoPathFn: func(_ context.Context, repoName, repoURL, localPath string) (string, error) {
+			return "/tmp/demo", nil
+		},
+		listBranchesFn: func(_ context.Context, repoPath string) ([]model.BranchInfo, error) {
+			return []model.BranchInfo{
+				{Name: "feature/active-work", QualifiedName: "feature/active-work", Scope: model.BranchScopeLocal},
+				{Name: "feature/other", QualifiedName: "feature/other", Scope: model.BranchScopeLocal},
+			}, nil
+		},
+		currentBranchFn: func(_ context.Context, repoPath string) (string, error) {
+			return "feature/active-work", nil
+		},
+		detectDefaultBranchFn: func(_ context.Context, repoPath, currentBranch string) (string, error) {
+			return "main", nil
+		},
+	}
+
+	v := viper.New()
+	v.Set("repos", []map[string]any{{
+		"name": "demo",
+		"path": "/tmp/demo",
+		"branch": map[string]any{
+			"autocheck": []string{"^feature/.*$"},
+		},
+	}})
+
+	cfg, err := config.LoadFromViper(v)
+	if err != nil {
+		t.Fatalf("load config from viper: %v", err)
+	}
+
+	cleaner := NewCleaner(git)
+	rb, err := cleaner.LoadRepoBranches(context.Background(), cfg.Repos[0])
+	if err != nil {
+		t.Fatalf("load repo branches: %v", err)
+	}
+
+	byName := make(map[string]model.BranchInfo, len(rb.Branches))
+	for _, b := range rb.Branches {
+		byName[b.Name] = b
+	}
+
+	// Current branch must NOT be autocheck-selected even if it matches regex
+	if byName["feature/active-work"].Autocheck {
+		t.Fatal("current branch must not be autocheck-selected")
+	}
+	// Other matching branch must be autocheck-selected
+	if !byName["feature/other"].Autocheck {
+		t.Fatal("feature/other must be autocheck-selected")
+	}
+}
+
+func TestLoadRepoBranchesAutocheckIsNoOpWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	git := &fakeGitClient{
+		resolveRepoPathFn: func(_ context.Context, repoName, repoURL, localPath string) (string, error) {
+			return "/tmp/demo", nil
+		},
+		listBranchesFn: func(_ context.Context, repoPath string) ([]model.BranchInfo, error) {
+			return []model.BranchInfo{
+				{Name: "feature/task", QualifiedName: "feature/task", Scope: model.BranchScopeLocal},
+			}, nil
+		},
+		currentBranchFn: func(_ context.Context, repoPath string) (string, error) {
+			return "main", nil
+		},
+		detectDefaultBranchFn: func(_ context.Context, repoPath, currentBranch string) (string, error) {
+			return "main", nil
+		},
+	}
+
+	repo := config.RepoConfig{Name: "demo", Path: "/tmp/demo"}
+	// No autocheck configured
+
+	cleaner := NewCleaner(git)
+	rb, err := cleaner.LoadRepoBranches(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("load repo branches: %v", err)
+	}
+
+	if rb.Branches[0].Autocheck {
+		t.Fatal("branch must not be autocheck-selected when autocheck is empty")
+	}
+}


### PR DESCRIPTION
#9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Автоматический предварительный выбор веток по настраиваемым шаблонам (autocheck) при загрузке репозитория; ручная отмена/переключение сохраняется.

* **Улучшения**
  * Жёсткая валидация сообщений коммитов: заголовок 10–100 символов, ограничение на длину футера и фиксированный набор типов коммитов.
  * Обновлён локальный клиентский хук для применения новой проверки коммитов.

* **Документация**
  * Обновлён пример конфигурации: добавлены шаблоны для autocheck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->